### PR TITLE
update setup.py to import setup() from setuptools (thereby adding support for bdist_egg)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,9 @@ compile_ext_mod = False
 # import statements
 import os
 import sys
-from distutils.core import setup, Extension
+from distutils.core import Extension
 from distutils.util import get_platform
+from setuptools import setup
 
 platform = get_platform()
 


### PR DESCRIPTION
I realize that a half-distutils/half-setuptools setup.py isn't the best thing -- but we needed to be able to do:

``` python
python setup.py bdist_egg
```

and this two line change let us do so. Please let me know If there's a better way you'd rather pull in, and thanks!
