### PR TITLE
add support for IN_EXCL_UNLINK flag

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -396,6 +396,10 @@ class EventsCodes:
                           IN_ONLYDIR we can make sure that we don't watch
                           the target of symlinks.
     @type IN_DONT_FOLLOW: int
+    @cvar IN_EXCL_UNLINK: Events are not generated for children after they
+                          have been unlinked from the watched directory.
+                          (new in kernel 2.6.36).
+    @type IN_EXCL_UNLINK: int
     @cvar IN_MASK_ADD: add to the mask of an already existing watch (new
                        in kernel 2.6.14).
     @type IN_MASK_ADD: int
@@ -434,6 +438,7 @@ class EventsCodes:
         'IN_ONLYDIR'       : 0x01000000,  # only watch the path if it is a
                                           # directory
         'IN_DONT_FOLLOW'   : 0x02000000,  # don't follow a symlink
+        'IN_EXCL_UNLINK'   : 0x04000000,  # exclude events on unlinked objects
         'IN_MASK_ADD'      : 0x20000000,  # add to the mask of an already
                                           # existing watch
         'IN_ISDIR'         : 0x40000000,  # event occurred against dir


### PR DESCRIPTION
IN_EXCL_UNLINK was added from kernel 2.6.36 but it's missing from the library.
If IN_EXCL_UNLINK  flag is enabled, events are not generated for children after they have been unlinked.
# simple usage

Imagine, while you're writing to a file, that file is unlinked.

```
$ mkdir /tmp/dir
$ cat > /tmp/dir/aaa
test
# another terminal $ unlink /tmp/dir/aaa
test
Type Control-D
```

If you're watching /tmp/dir, following events are triggered :

```
$ python pyinotify.py --events-list ALL_EVENTS /tmp/dir/
<Event dir=False mask=0x100 maskname=IN_CREATE name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 > #  $ cat > /tmp/dir/aaa
<Event dir=False mask=0x20 maskname=IN_OPEN name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 > 
<Event dir=False mask=0x2 maskname=IN_MODIFY name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 >
<Event dir=False mask=0x200 maskname=IN_DELETE name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 >
<Event dir=False mask=0x2 maskname=IN_MODIFY name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 >
<Event dir=False mask=0x8 maskname=IN_CLOSE_WRITE name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 >
```

If IN_EXCL_UNLINK  flag is enabled, the last two events(events after unlinking) are not triggered:

```
$ python pyinotify.py --events-list ALL_EVENTS,IN_EXCL_UNLINK /tmp/dir/

<Event dir=False mask=0x100 maskname=IN_CREATE name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 > #  $ cat > /tmp/dir/aaa
<Event dir=False mask=0x20 maskname=IN_OPEN name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 > 
<Event dir=False mask=0x2 maskname=IN_MODIFY name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 >
<Event dir=False mask=0x200 maskname=IN_DELETE name=aaa path=/tmp/dir pathname=/tmp/dir/aaa wd=1 >
# no further events are triggered for /tmp/dir/aaa
```
