### PR TITLE
py-2.5 removed from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.6"
   - "2.7"
   - "3.2"
+  - "3.3"
   - "pypy"
 script: /bin/true


### PR DESCRIPTION
http://about.travis-ci.org/blog/2013-11-18-upcoming-build-environment-updates/

Assuming py-2.4 got removed longer ago.
