### PR TITLE
Fix for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 
 ## Dependencies
 
-* Linux ≥ 2.6.13
+* Linux ≥ 2.6.13 
+or
+* FreeBSD with the inotify library installed from the ports collection
+
 * Python ≥ 2.4 (including Python 3.x)
 
 

--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -55,6 +55,7 @@ if sys.version_info < (2, 4):
 # Import directives
 import threading
 import os
+import platform
 import select
 import struct
 import fcntl
@@ -203,8 +204,12 @@ class _CtypesLibcINotifyWrapper(INotifyWrapper):
     def init(self):
         assert ctypes
         libc_name = None
+        try_libname = 'c'
+        if platform.system().startswith('FreeBSD'):
+            try_libcname = 'inotify'
+
         try:
-            libc_name = ctypes.util.find_library('c')
+            libc_name = ctypes.util.find_library(try_libcname)
         except (OSError, IOError):
             pass  # Will attemp to load it with None anyway.
 

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -56,6 +56,7 @@ if sys.version_info < (3, 0):
 # Import directives
 import threading
 import os
+import platform
 import select
 import struct
 import fcntl
@@ -201,8 +202,13 @@ class _CtypesLibcINotifyWrapper(INotifyWrapper):
     def init(self):
         assert ctypes
         libc_name = None
+
+        try_libname = 'c'
+        if platform.system().startswith('FreeBSD'):
+            try_libcname = 'inotify'
+
         try:
-            libc_name = ctypes.util.find_library('c')
+            libc_name = ctypes.util.find_library(try_libcname)
         except (OSError, IOError):
             pass  # Will attemp to load it with None anyway.
 

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,11 @@ if sys.version_info < (2, 4):
 
 # check linux platform
 if not platform.startswith('linux'):
-    sys.stderr.write("inotify is not available on %s\n" % platform)
-    sys.exit(1)
+    if platform.startswith('freebsd'):
+       sys.stderr.write("On FreeBSD you will need to install the libinotify from the ports collection for this to work\n")
+    else:
+       sys.stderr.write("inotify is not available on %s\n" % platform)
+       sys.exit(1)
 
 
 classif = [
@@ -67,8 +70,12 @@ def should_compile_ext_mod():
         return True
 
     libc_name = None
+    try_libname = 'c'
+    if platform.startswith('freebsd'):
+        try_libcname = 'inotify'
+
     try:
-        libc_name = ctypes.util.find_library('c')
+        libc_name = ctypes.util.find_library(try_libcname)
     except:
         pass  # Will attemp to load it with None anyway.
 


### PR DESCRIPTION
Hi,
The module works reasonably well on FreeBSD with the libinotify installed from the ports collection.

I've been using it there with the Airtime software and there hasn't been any problems except that it may generate different events than those documented on occasion :)

Thanks for making a useful library.
