### PR TITLE
Fixed an issue with the path of watched directories after they are moved...

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -782,6 +782,9 @@ class _SysProcessEvent(_ProcessEvent):
             # to provide as additional information to the IN_MOVED_TO event
             # the original pathname of the moved file/directory.
             to_append['src_pathname'] = mv_[0]
+            for watch__ in self._watch_manager.watches.values():
+                if watch__.path.startswith(mv_[0]):
+                    watch__.path=watch__.path.replace(mv_[0],dst_path,1)
         elif (raw_event.mask & IN_ISDIR and watch_.auto_add and
               not watch_.exclude_filter(dst_path)):
             # We got a diretory that's "moved in" from an unknown source and

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -772,6 +772,11 @@ class _SysProcessEvent(_ProcessEvent):
             # to provide as additional information to the IN_MOVED_TO event
             # the original pathname of the moved file/directory.
             to_append['src_pathname'] = mv_[0]
+            # When a directory is moved, we must update the path in all
+            # watches within            
+            for watch__ in self._watch_manager.watches.values():
+                if watch__.path.startswith(mv_[0]):
+                    watch__.path=watch__.path.replace(mv_[0],dst_path,1)
         elif (raw_event.mask & IN_ISDIR and watch_.auto_add and
               not watch_.exclude_filter(dst_path)):
             # We got a diretory that's "moved in" from an unknown source and


### PR DESCRIPTION
....

To replicate the issue:
mkdir dir1/dir2

create watches on dir1 and dir2 and starting a watching process

cd dir1
mv dir2 dir3
touch dir3/emptyfile

The path reported in the event is dir1/dir2, not dir1/dir3
