### PR TITLE
Allow TornadoAsyncNotifier.stop() to clean up all hanging refs.

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -1447,6 +1447,7 @@ class Notifier:
         """
         self._pollobj.unregister(self._fd)
         os.close(self._fd)
+        self._sys_proc_fun = None
 
 
 class ThreadedNotifier(threading.Thread, Notifier):
@@ -1592,6 +1593,10 @@ class TornadoAsyncNotifier(Notifier):
         Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
                           threshold, timeout)
         ioloop.add_handler(self._fd, self.handle_read, ioloop.READ)
+
+    def stop(self):
+      self.io_loop.remove_handler(self._fd)
+      Notifier.stop(self)
 
     def handle_read(self, *args, **kwargs):
         """

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -1437,6 +1437,7 @@ class Notifier:
         """
         self._pollobj.unregister(self._fd)
         os.close(self._fd)
+        self._sys_proc_fun = None
 
 
 class ThreadedNotifier(threading.Thread, Notifier):
@@ -1582,6 +1583,10 @@ class TornadoAsyncNotifier(Notifier):
         Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
                           threshold, timeout)
         ioloop.add_handler(self._fd, self.handle_read, ioloop.READ)
+
+    def stop(self):
+      self.io_loop.remove_handler(self._fd)
+      Notifier.stop(self)
 
     def handle_read(self, *args, **kwargs):
         """


### PR DESCRIPTION
Without this, the TornadoAsyncNotifier and thus WatchManager instances are
never freed, because tornado is still holding a refernce to the handler.
