### PR TITLE
move platform check to import time not install time

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -51,6 +51,13 @@ import sys
 if sys.version_info < (2, 4):
     raise UnsupportedPythonVersionError(sys.version)
 
+# check linux platform
+import platform
+system = platform.system().lower()
+if not system.startswith('linux') and not system.startswith('freebsd'):
+    sys.stderr.write("inotify is not available on %s\n" % system)
+    sys.exit(1)
+
 
 # Import directives
 import threading

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -52,6 +52,12 @@ import sys
 if sys.version_info < (3, 0):
     raise UnsupportedPythonVersionError(sys.version)
 
+# check linux platform
+import platform
+system = platform.system().lower()
+if not system.startswith('linux') and not system.startswith('freebsd'):
+    sys.stderr.write("inotify is not available on %s\n" % system)
+    sys.exit(1)
 
 # Import directives
 import threading

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,6 @@ if sys.version_info < (2, 4):
     sys.stderr.write('This module requires at least Python 2.4\n')
     sys.exit(1)
 
-# check linux platform
-if not platform.startswith('linux') and not platform.startswith('freebsd'):
-    sys.stderr.write("inotify is not available on %s\n" % platform)
-    sys.exit(1)
-
-
 classif = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',


### PR DESCRIPTION
I'd like to use pyinotify for an optional feature, but I can't add it to my `requirements.txt` because `pip install` will fail for devs on non-Linux platforms (Mac being the most prevalent)

What do you think about moving the platform check into the module so it runs at import time (like the existing Python version check)?
