### PR TITLE
Fix garbage collection of Notifier

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -69,6 +69,7 @@ import time
 import re
 import asyncore
 import subprocess
+import weakref
 
 try:
     from functools import reduce
@@ -675,7 +676,7 @@ class _SysProcessEvent(_ProcessEvent):
         @type notifier: Notifier instance
         """
         self._watch_manager = wm  # watch manager
-        self._notifier = notifier  # notifier
+        self._notifier = weakref.ref(notifier)  # notifier
         self._mv_cookie = {}  # {cookie(int): (src_path(str), date), ...}
         self._mv = {}  # {src_path(str): (dst_path(str), date), ...}
 
@@ -733,7 +734,7 @@ class _SysProcessEvent(_ProcessEvent):
                                 # This path should not be taken.
                                 continue
                             rawevent = _RawEvent(created_dir_wd, flags, 0, name)
-                            self._notifier.append_event(rawevent)
+                            self._notifier().append_event(rawevent)
                     except OSError, err:
                         msg = "process_IN_CREATE, invalid directory %s: %s"
                         log.debug(msg % (created_dir, str(err)))
@@ -1158,6 +1159,9 @@ class Notifier:
         self._coalesce = False
         # set of str(raw_event), only used when coalesce option is True
         self._eventset = set()
+
+    def __del__(self):
+        self.stop()
 
     def append_event(self, event):
         """


### PR DESCRIPTION
This uses a weak reference to the notifier in `_SysProcessEvent` and adds
a `__del__` method for Notifier.

This prevents pyinotify from leaking inotify file descriptors
(instances) and its watches.

Fixes https://github.com/seb-m/pyinotify/issues/95

I have used the following script to test it:

```
from __future__ import print_function

import gc
import os

from pyinotify import Notifier, WatchManager

def has_inotify_fds():
    "Does the current process have inotify fds?"
    r = 0
    for x in os.walk('/proc/{}/fd'.format(os.getpid())):
        for y in x[2]:
            path = os.path.join(x[0], y)
            if os.path.exists(path):
                if 'inotify' in os.path.join(os.readlink(path)):
                    r += 1
    return r

gc.disable()

wm = WatchManager()
n = Notifier(wm)
assert has_inotify_fds() == 1

# Stopping multiple times should work:
n.stop()
assert has_inotify_fds() == 0
n.stop()

gc.collect()
# XXX: needs a new WatchManager, because the previous fd gets closed by stop!
wm = WatchManager()
n = Notifier(wm)
assert has_inotify_fds() == 1

# Collect anything.
gc.collect()
assert n in gc.get_objects()

n = None
assert gc.garbage == []
assert not any(isinstance(x, Notifier) for x in gc.garbage)
assert not any(isinstance(x, Notifier) for x in gc.get_objects())

assert has_inotify_fds() == 0
```
