### PR TITLE
Ignore SIGCHLD to avoid generating zombie process

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -69,6 +69,7 @@ import time
 import re
 import asyncore
 import subprocess
+import signal
 
 try:
     from functools import reduce
@@ -2383,4 +2384,5 @@ def command_line():
 
 
 if __name__ == '__main__':
+    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
     command_line()

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -72,6 +72,7 @@ import asyncore
 import glob
 import locale
 import subprocess
+import signal
 
 try:
     from functools import reduce
@@ -2362,4 +2363,5 @@ def command_line():
 
 
 if __name__ == '__main__':
+    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
     command_line()


### PR DESCRIPTION
This fixes #112.  We do not care about the exit status from child process anyway.

Verified with python 2.7.5.

```
% ./python2/pyinotify.py -e IN_MODIFY -f /tmp/input.log -c 'sleep 1' & sleep 2; echo hello > /tmp/input.log
[1] 30251
<Event dir=False mask=0x2 maskname=IN_MODIFY name='' path=/tmp/input.log pathname=/tmp/input.log wd=1 >
<Event dir=False mask=0x2 maskname=IN_MODIFY name='' path=/tmp/input.log pathname=/tmp/input.log wd=1 >

% pgrep -lf defunct
[no output]
```
