### PR TITLE
surrogateescape added

### DIFF
--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -243,7 +243,7 @@ class _CtypesLibcINotifyWrapper(INotifyWrapper):
         # ctypes.create_string_buffer seems to manipulate bytes internally.
         # Moreover it seems that inotify_add_watch does not work very well when
         # it receives an ctypes.create_unicode_buffer instance as argument.
-        pathname = pathname.encode(sys.getfilesystemencoding())
+        pathname = pathname.encode(sys.getfilesystemencoding(), errors='surrogateescape')
         pathname = ctypes.create_string_buffer(pathname)
         return self._libc.inotify_add_watch(fd, pathname, mask)
 
@@ -1236,7 +1236,7 @@ class Notifier:
             bname, = struct.unpack('%ds' % fname_len,
                                    r[rsum + s_size:rsum + s_size + fname_len])
             # FIXME: should we explictly call sys.getdefaultencoding() here ??
-            uname = bname.decode()
+            uname = bname.decode(errors='surrogateescape')
             rawevent = _RawEvent(wd, mask, cookie, uname)
             if self._coalesce:
                 # Only enqueue new (unique) events.


### PR DESCRIPTION
I am watching pretty large filesystem on hosting server.
Files and Dirs with "wrong" characters appear time to time and I don't want just skip them
this patch helped me to handler them well

inspired by this http://lucumr.pocoo.org/2013/7/2/the-updated-guide-to-unicode/
( surrogate escaping part )

Thanks
