### PR TITLE
Fix iterable detection in WatchManager.__format_param

### DIFF
--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -65,6 +65,7 @@ import array
 import logging
 import atexit
 from collections import deque
+from collections import Iterable
 from datetime import datetime, timedelta
 import time
 import re
@@ -2045,7 +2046,7 @@ class WatchManager:
         @return: wrap param.
         @rtype: list of type(param)
         """
-        if isinstance(param, list):
+        if isinstance(param, Iterable):
             for p_ in param:
                 yield p_
         else:


### PR DESCRIPTION
In python3, dict.values() is not a list but dict_values, which breaks
code like wm.rm_watch(wdd.values()) from tutorial.
