### PR TITLE
Catch RuntimeError in _CtypesLibcINotifyWrapper

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -213,7 +213,7 @@ class _CtypesLibcINotifyWrapper(INotifyWrapper):
         libc_name = None
         try:
             libc_name = ctypes.util.find_library(try_libc_name)
-        except (OSError, IOError):
+        except (OSError, IOError, RuntimeError):
             pass  # Will attemp to load it with None anyway.
 
         if sys.version_info >= (2, 6):


### PR DESCRIPTION
On Synology DSM 6.0, `_CtypesLibcINotifyWrapper`'s constructor throws a `RuntimeError`. Catching this error allows the code to still attempt to load the library (with `libc_name` set to `None`).

This workaround has been described in the following forum post (written in German): 
http://www.synology-forum.de/showthread.html?74466-L%C3%B6sung-f%C3%BCr-das-Problem-mit-pyinotify-und-DSM-6
