### PR TITLE
allow me to not care in the slightest about these events

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -1263,7 +1263,7 @@ class Notifier:
                 self._eventq.append(rawevent)
             rsum += s_size + fname_len
 
-    def process_events(self):
+    def process_events(self, ignore_missing=False):
         """
         Routine for processing events from queue by calling their
         associated proccessing method (an instance of ProcessEvent).
@@ -1276,7 +1276,7 @@ class Notifier:
                 continue
             watch_ = self._watch_manager.get_watch(raw_event.wd)
             if (watch_ is None) and not (raw_event.mask & IN_Q_OVERFLOW):
-                if not (raw_event.mask & IN_IGNORED):
+                if not ignore_missing and not (raw_event.mask & IN_IGNORED):
                     # Not really sure how we ended up here, nor how we should
                     # handle these types of events and if it is appropriate to
                     # completly skip them (like we are doing here).

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -1248,7 +1248,7 @@ class Notifier:
                 self._eventq.append(rawevent)
             rsum += s_size + fname_len
 
-    def process_events(self):
+    def process_events(self, ignore_missing=False):
         """
         Routine for processing events from queue by calling their
         associated proccessing method (an instance of ProcessEvent).
@@ -1261,7 +1261,7 @@ class Notifier:
                 continue
             watch_ = self._watch_manager.get_watch(raw_event.wd)
             if (watch_ is None) and not (raw_event.mask & IN_Q_OVERFLOW):
-                if not (raw_event.mask & IN_IGNORED):
+                if not ignore_missing and not (raw_event.mask & IN_IGNORED):
                     # Not really sure how we ended up here, nor how we should
                     # handle these types of events and if it is appropriate to
                     # completly skip them (like we are doing here).


### PR DESCRIPTION
We have a loop going that sometimes takes quite a while (https://github.com/hubblestack/hubble/blob/develop/hubblestack/extmods/modules/pulsar.py#L726). Occasionally, if the loop takes too long or something happens externally during the loop, some of the watches seem to disappear doing the `process_events()`. I'm not totally sure what causes it. Is it the kernel canceling the watch and therefore `get_watch(raw_event.wd)` is failing? are we externally modifying the watchlist during the `process_events()`? Not sure. What I can say is that it's always very shortly lived temp files that trigger this error.

I'm confident the missing watches are safe to ignore. The 30,000 hosts reporting this error for /opt/specialthing/whatever is wasting quite a lot of space in our log analyzer. And we'd really rather keep watching the specialthing/whatever directory, even though it has quite a lot of tempfiles that pop in/out.

Let me know if you think this is a wrongheaded way to solve the problem or have a better idea what else we could fix.

Thanks.
