### PR TITLE
Remove pointless .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "pypy"
-script: /bin/true


### PR DESCRIPTION
The script only executes /bin/true; not actual tests. Better to not mislead contributors that tests are running.