### PR TITLE
Drop support for end-of-life Pythons

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Dependencies
 
 * Linux ≥ 2.6.13
-* Python ≥ 2.4 (including Python 3.x)
+* Python 2.7 or 3.4+
 
 
 ## Install
@@ -21,7 +21,7 @@
 
 ### Or install Pyinotify directly from source
 
-    # Choose your Python interpreter: either python, python2.7, python3.2,..
+    # Choose your Python interpreter: either python, python2.7, python3.4, ...
     # Replacing XXX accordingly, type:
     $ sudo pythonXXX setup.py install
 

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -44,12 +44,12 @@ class UnsupportedPythonVersionError(PyinotifyError):
         """
         PyinotifyError.__init__(self,
                                 ('Python %s is unsupported, requires '
-                                 'at least Python 3.0') % version)
+                                 'at least Python 3.4') % version)
 
 
 # Check Python version
 import sys
-if sys.version_info < (3, 0):
+if sys.version_info < (3, 4):
     raise UnsupportedPythonVersionError(sys.version)
 
 
@@ -72,17 +72,9 @@ import asyncore
 import glob
 import locale
 import subprocess
-
-try:
-    from functools import reduce
-except ImportError:
-    pass  # Will fail on Python 2.4 which has reduce() builtin anyway.
-
-try:
-    import ctypes
-    import ctypes.util
-except ImportError:
-    ctypes = None
+from functools import reduce
+import ctypes
+import ctypes.util
 
 try:
     import inotify_syscalls
@@ -121,10 +113,9 @@ class INotifyWrapper:
         Factory method instanciating and returning the right wrapper.
         """
         # First, try to use ctypes.
-        if ctypes:
-            inotify = _CtypesLibcINotifyWrapper()
-            if inotify.init():
-                return inotify
+        inotify = _CtypesLibcINotifyWrapper()
+        if inotify.init():
+            return inotify
         # Second, see if C extension is compiled.
         if inotify_syscalls:
             inotify = _INotifySyscallsWrapper()
@@ -199,8 +190,6 @@ class _CtypesLibcINotifyWrapper(INotifyWrapper):
         self._get_errno_func = None
 
     def init(self):
-        assert ctypes
-
         try_libc_name = 'c'
         if sys.platform.startswith('freebsd'):
             try_libc_name = 'inotify'

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,13 @@ import os
 import sys
 import distutils.extension
 from distutils.util import get_platform
-try:
-    # First try to load most advanced setuptools setup.
-    from setuptools import setup
-except:
-    # Fall back if setuptools is not installed.
-    from distutils.core import setup
+from setuptools import setup
 
 platform = get_platform()
 
 # check Python's version
-if sys.version_info < (2, 4):
-    sys.stderr.write('This module requires at least Python 2.4\n')
+if sys.version_info < (2, 7):
+    sys.stderr.write('This module requires at least Python 2.7\n')
     sys.exit(1)
 
 # check linux platform
@@ -38,16 +33,13 @@ classif = [
     'Natural Language :: English',
     'Operating System :: POSIX :: Linux',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2.4',
-    'Programming Language :: Python :: 2.5',
-    'Programming Language :: Python :: 2.6',
+    'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.0',
-    'Programming Language :: Python :: 3.1',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries :: Python Modules',
@@ -115,4 +107,5 @@ setup(
     ext_modules=ext_mod,
     py_modules=['pyinotify'],
     package_dir=package_dir,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     )


### PR DESCRIPTION
Python 2.6 and 3.3 are end-of-life. They are no longer receiving bug fixes, including for security issues. Python 2.6 went EOL on 2013-10-29 and Python 3.3 on 2017-09-29. For additional details on supported Python versions, see:

Active branches: https://devguide.python.org/#status-of-python-branches
End-of-life branches: https://devguide.python.org/devcycle/#end-of-life-branches

Removing support for EOL Pythons will reduce testing and maintenance resources. For example, can begin moving towards a unified Python 2/3 version of pyinotify, reducing massive duplication.

Using pypinfo, here are the download statistic for the last 30 days, showing very low numbers for EOL Pythons.

```
$ pypinfo --percent --markdown pyinotify pyversion
```

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  64.70% |        190,361 |
| 3.5            |  28.04% |         82,493 |
| 3.6            |   4.68% |         13,763 |
| 3.4            |   1.69% |          4,973 |
| 3.7            |   0.56% |          1,633 |
| 2.6            |   0.27% |            790 |
| 3.3            |   0.07% |            202 |
| None           |   0.00% |              3 |
| Total          |         |        294,218 |

Changes:

- Can assume functools.reduce always exists
- Can assume ctypes always exists
- Can assume glob.iglob always exists
- Use modern exception handling format (more forward compatible)
- Can use context managers
- Can use octal literal syntax