### PR TITLE
FIX: Python segfaults on alphine linux when call read_event #131

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -1228,7 +1228,9 @@ class Notifier:
         """
         buf_ = array.array('i', [0])
         # get event queue size
-        if fcntl.ioctl(self._fd, termios.FIONREAD, buf_, 1) == -1:
+        # don't pass `mutate_flag` to the `fcntl.ioctl`, it may cause segfault on some 
+        # systems, e.g. alpine linux (see https://bugs.alpinelinux.org/issues/5981)
+        if fcntl.ioctl(self._fd, termios.FIONREAD, buf_) == -1:
             return
         queue_size = buf_[0]
         if queue_size < self._threshold:


### PR DESCRIPTION
I've got segfault on Alpine linux with python 2.7 that caused by `ioctl` syscall calling (https://bugs.alpinelinux.org/issues/5981). 
Starting from python 2.5 `mutate_flag` is `True` by default, so explicit passing can be removed.