### PR TITLE
Add RuntimeError to possible exceptions when searching for libc

### DIFF
--- a/python2/pyinotify.py
+++ b/python2/pyinotify.py
@@ -213,7 +213,7 @@ class _CtypesLibcINotifyWrapper(INotifyWrapper):
         libc_name = None
         try:
             libc_name = ctypes.util.find_library(try_libc_name)
-        except (OSError, IOError):
+        except (OSError, IOError, RuntimeError):
             pass  # Will attemp to load it with None anyway.
 
         if sys.version_info >= (2, 6):

--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -208,7 +208,7 @@ class _CtypesLibcINotifyWrapper(INotifyWrapper):
         libc_name = None
         try:
             libc_name = ctypes.util.find_library(try_libc_name)
-        except (OSError, IOError):
+        except (OSError, IOError, RuntimeError):
             pass  # Will attemp to load it with None anyway.
 
         self._libc = ctypes.CDLL(libc_name, use_errno=True)


### PR DESCRIPTION
Pyinotify throws an exception on Synology DiskStation systems, because `ctypes.util.find_library()` throws a `RuntimeError` instead of the expected `OSError` or `IOError`.

This PR fixes this by adding `RuntimeError` to the list of expected exception types.