### PR TITLE
Remove duplicate license parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ setup(
     description='Linux filesystem events monitoring',
     author='Sebastien Martini',
     author_email='seb@dbzteam.org',
-    license='MIT License',
     platforms='Linux',
     classifiers=classif,
     url='http://github.com/seb-m/pyinotify',


### PR DESCRIPTION
The [Python packaging specifications](https://packaging.python.org/specifications/core-metadata) indicate that the [`license` parameter](https://packaging.python.org/specifications/core-metadata/#license) to `setup()` should be used in one of the following cases:

* the license is not a selection from the “License” Trove classifiers
* to specify a particular version of a license which is named via the `Classifier` field
* to indicate a variation or exception to such a license

This PR removes the explicit `license` parameter since the usage for this project does not fit any of those cases and it makes it more difficult to use tools like [pip-licenses](https://pypi.org/project/pip-licenses) since it is not consistent with other projects that just have `License :: OSI Approved :: MIT License` as one of their trove classifiers.

Please note that this does _not_ change the license of the project in any way, and since this project already has a `License :: OSI Approved :: MIT License` trove classifier the `license` parameter is redundant.