### PR TITLE
add support for pathlib objects, improve logging, fixes #187

### DIFF
--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -1903,9 +1903,16 @@ class WatchManager:
 
         # normalize args as list elements
         for npath in self.__format_param(path):
-            # Require that path be a unicode string
+            # attempt to cast to string so that pathlib objects are supported
+            try:
+                npath = str(path)
+            except ValueError:
+                pass
+
+            # require that path be a unicode string
             if not isinstance(npath, str):
                 ret_[path] = -3
+                log.error('add_watch: invalid path "%s"' % repr(path))
                 continue
 
             # unix pathname pattern expansion


### PR DESCRIPTION
It would be good that pyinotify works with pathlib Path objects (see https://docs.python.org/3.8/library/pathlib.html); currently, the behaviour is that the path is silently dropped, which makes it quite hard to debug.

This MR suggests:
* casting to string whenever possible (makes pathlib objects work)
* adds a more explicit error when not possible to cast to string