### PR TITLE
Make asyncore support optional for Python 3.

### DIFF
--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -68,7 +68,6 @@ from collections import deque
 from datetime import datetime, timedelta
 import time
 import re
-import asyncore
 import glob
 import locale
 import subprocess
@@ -1494,33 +1493,40 @@ class ThreadedNotifier(threading.Thread, Notifier):
         self.loop()
 
 
-class AsyncNotifier(asyncore.file_dispatcher, Notifier):
-    """
-    This notifier inherits from asyncore.file_dispatcher in order to be able to
-    use pyinotify along with the asyncore framework.
+try:
+    import asyncore
 
-    """
-    def __init__(self, watch_manager, default_proc_fun=None, read_freq=0,
-                 threshold=0, timeout=None, channel_map=None):
+    class AsyncNotifier(asyncore.file_dispatcher, Notifier):
         """
-        Initializes the async notifier. The only additional parameter is
-        'channel_map' which is the optional asyncore private map. See
-        Notifier class for the meaning of the others parameters.
+        This notifier inherits from asyncore.file_dispatcher in order to be able to
+        use pyinotify along with the asyncore framework.
 
         """
-        Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
-                          threshold, timeout)
-        asyncore.file_dispatcher.__init__(self, self._fd, channel_map)
+        def __init__(self, watch_manager, default_proc_fun=None, read_freq=0,
+                     threshold=0, timeout=None, channel_map=None):
+            """
+            Initializes the async notifier. The only additional parameter is
+            'channel_map' which is the optional asyncore private map. See
+            Notifier class for the meaning of the others parameters.
 
-    def handle_read(self):
-        """
-        When asyncore tells us we can read from the fd, we proceed processing
-        events. This method can be overridden for handling a notification
-        differently.
+            """
+            Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
+                              threshold, timeout)
+            asyncore.file_dispatcher.__init__(self, self._fd, channel_map)
 
-        """
-        self.read_events()
-        self.process_events()
+        def handle_read(self):
+            """
+            When asyncore tells us we can read from the fd, we proceed processing
+            events. This method can be overridden for handling a notification
+            differently.
+
+            """
+            self.read_events()
+            self.process_events()
+except ImportError:
+    # asyncore was removed in Python 3.12, but try the import instead of a
+    # version check in case the compatibility package is installed.
+    pass
 
 
 class TornadoAsyncNotifier(Notifier):


### PR DESCRIPTION
Simple fix for Python 3.12 since it dropped asyncore. Catches the import error instead of using a version check so that the user can install the compatibility package for any uses that can't be upgraded to asyncio or similar immediately.
 
Fixes #204.